### PR TITLE
Avoid single winner banner in group mode

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1033,7 +1033,7 @@ export default function App() {
           </div>
 
           {/* Winner banner */}
-          {currentWinner && (
+          {!groupMode && currentWinner && (
             <div className="relative rounded-2xl p-6 bg-[#161616]/90 border border-[#27272A] overflow-hidden">
               <Confetti show={showConfetti} />
               <div className="relative z-10 flex items-center justify-between">


### PR DESCRIPTION
## Summary
- hide single-winner banner when using group draw mode

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfdc94f11883259eaf72c0bd69a2a8